### PR TITLE
Fix/ins template

### DIFF
--- a/src/main/java/uk/ac/imperial/libhpc2/tempss/xml/TemPSSSchemaBuilder.java
+++ b/src/main/java/uk/ac/imperial/libhpc2/tempss/xml/TemPSSSchemaBuilder.java
@@ -268,6 +268,8 @@ public class TemPSSSchemaBuilder {
 			if(node.hasAttributes()) {
 				Attribute optionalAttr = node.getAttribute("optional");
 				Attribute repeatableAttr = node.getAttribute("repeatable");
+				Attribute functionAttr = node.getAttribute("function");
+				String functionType = "";
 				boolean optional = false;
 				if(optionalAttr != null) {
 					try {
@@ -307,6 +309,15 @@ public class TemPSSSchemaBuilder {
 					// Don't need to put maxOccurs if we didn't have minOccurs
 					if(optionalAttr != null) {
 						e.setAttribute("maxOccurs", "1");
+					}
+				}
+				if(functionAttr != null) {
+					functionType = functionAttr.getValue();
+					if(functionType.equals("functionSource")) {
+						e.setAttribute("type", "FunctionType");
+					}
+					else if(functionType.equals("functionTarget")) {
+						e.setAttribute("type", "FunctionTargetType");
 					}
 				}
 			}

--- a/src/main/resources/Schema/IncompressibleNavierStokes.xml
+++ b/src/main/resources/Schema/IncompressibleNavierStokes.xml
@@ -393,29 +393,10 @@
         </Threshold>
       </FilterType>
     </Filter>
-
-    <Force repeatable="true" paramType="choice" optional="true">
+    
+    <Function repeatable="true" optional="true" function="functionSource">
       <libhpc:documentation>
-        An optional section of the file allows forcing functions to be defined.
-      </libhpc:documentation>
-      <Absorption>
-        <Coeff type="xs:string"/>
-        <RefFlow type="xs:string"/>
-        <RefFlowTime type="xs:string"/>
-      </Absorption>
-      <Body>
-        <BodyForce type="xs:string"/>
-      </Body>
-      <Noise>
-        <Whitenoise type="positiveDouble"/>
-        <UpdateFreq type="positiveDouble" optional="true"/>
-        <Nsteps type="positiveDouble" optional="true"/>
-      </Noise>
-    </Force>
-
-    <Function repeatable="true" optional="true">
-      <libhpc:documentation>
-        Add in custom functions .
+        Add in custom functions.
       </libhpc:documentation>
       <FunctionName type="xs:string"/>
         <Expression repeatable="true">
@@ -423,6 +404,29 @@
           <ExpressionValue type="xs:string"/>
         </Expression>
     </Function>
+
+    <Force repeatable="true" paramType="choice" optional="true">
+      <libhpc:documentation>
+        An optional section of the file allows forcing functions to be defined. 
+      </libhpc:documentation>
+      <Absorption>
+        <Coeff type="xs:string"/>
+        <RefFlow type="xs:string"/>
+        <RefFlowTime type="xs:string"/>
+      </Absorption>
+      <Body>
+        <BodyForce function="functionTarget">
+          <libhpc:documentation>
+            A function describing how the bodyforce is applied. Add a new function under Additional Parameters -> Function and it will appear in the list here for selection.
+          </libhpc:documentation>
+        </BodyForce>
+      </Body>
+      <Noise>
+        <Whitenoise type="positiveDouble"/>
+        <UpdateFreq type="positiveDouble" optional="true"/>
+        <Nsteps type="positiveDouble" optional="true"/>
+      </Noise>
+    </Force>
   </AdditionalParameters>
 
   <AdvancedParameters>

--- a/src/main/resources/Schema/NektarTypes.xsd
+++ b/src/main/resources/Schema/NektarTypes.xsd
@@ -414,5 +414,10 @@
       </xs:sequence>
     </xs:element>
   </xs:complexType>
+  
+  <xs:simpleType name="FunctionTargetType">
+    <xs:restriction base="xs:string">
+    </xs:restriction>
+  </xs:simpleType>
 
 </xs:schema>

--- a/src/main/resources/Transform/NektarBoundaryDetails.xsl
+++ b/src/main/resources/Transform/NektarBoundaryDetails.xsl
@@ -66,7 +66,7 @@
     <xsl:variable name="icount"><xsl:number/></xsl:variable>
     
     <REGION>
-      <xsl:attribute name="REF"><xsl:value-of select="BoundaryConditionReference"/></xsl:attribute>
+      <xsl:attribute name="REF"><xsl:value-of select="exslt:node-set($mappings)/MAPPING[@BCNAME=$bcname]/@ID"/></xsl:attribute>
       <!-- <xsl:apply-templates select="Variable" mode ="BCVariable"/> -->
       <xsl:choose>
         <xsl:when  test="Variable/CoupledLinearisedNS-2D">

--- a/src/main/resources/Transform/XsdToHtmlTransform.xsl
+++ b/src/main/resources/Transform/XsdToHtmlTransform.xsl
@@ -47,6 +47,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     <xsl:param name="optional" select="@minOccurs = '0'"/>
     <!-- Test to see if element is repeatable, based on maxOccurs -->
     <xsl:param name="repeatable" select="@maxOccurs and @maxOccurs != '1'"/>
+    
     <xsl:element name="ul">
       <!-- If this is a repeatable element, add a count with the data-repeat
            attribute.  -->
@@ -100,6 +101,12 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
         <xsl:attribute name="data-fqname">
           <xsl:value-of select="$nodeName"/>
         </xsl:attribute>
+        <xsl:if test="@type='FunctionType'">
+          <xsl:attribute name="data-function">true</xsl:attribute>
+        </xsl:if>
+        <xsl:if test="@type='FunctionTargetType'">
+          <xsl:attribute name="data-function-target">true</xsl:attribute>
+        </xsl:if>
         <xsl:element name="span">
           <!-- Add optional class if required, and optional data attribute -->
           <xsl:choose>

--- a/src/main/webapp/assets/js/libhpc-parameter-tree.js
+++ b/src/main/webapp/assets/js/libhpc-parameter-tree.js
@@ -559,22 +559,12 @@ function isInteger(valueToCheck) {
                 // they're all unique. This also ensures that we don't get 
                 // strange behaviour caused by having multiple toggles with 
                 // the same ID.
-                // Build a dictionary to keep track of the nodes we've seen
-                var repeatedNodes = {};
+                // Update: This has been simplified by just adding a short UID
+                // to each node's ID.
                 $toggleBtns.each(function() {
                 	var $this = $(this);
-                	// When this is run all the IDs are at their original vals
-                	// so we don't need to do a substring to remove any trailing
-                	// values since these haven't yet been added.
                 	var id = $this.attr('id');
-                	if(id in repeatedNodes) {
-                		var count = repeatedNodes[id];
-                		$this.attr('id', id+"-"+count);
-                		repeatedNodes[id] = count + 1;
-                	}
-                	else {
-                		repeatedNodes[id] = 1;
-                	}
+                	$this.attr('id', id+"-"+getSimpleUid(8));
                 });
                 $toggleBtns.candlestick({
                 	swipe:false, 
@@ -1955,4 +1945,16 @@ function resetEnableCandlestick($input) {
 	
 	$input.candlestick('reset');
 	$input.candlestick('enable');
+}
+
+function getSimpleUid(uidLength) {
+	var domain = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+	// Pick a random value, mod it with the length of domain and then select the
+	// value at that location. Repeat "length" times to give a random id.
+	uid = ""
+	for(var i = 0; i < uidLength; i++) {
+		var rand = Math.floor(Math.random()*domain.length);
+		uid += domain[rand]
+	}
+	return uid;
 }


### PR DESCRIPTION
Updates to INS template:
 - Fixed incorrect generation of boundary condition ID in transform
 - Added handling of functions and links to tree elements that use them
 - Added storage of tristate toggle status when switched off to avoid confusion between off and unset.